### PR TITLE
fix(ci): restore Common Go checks

### DIFF
--- a/cmd/aptre/cmd-deps.go
+++ b/cmd/aptre/cmd-deps.go
@@ -56,7 +56,7 @@ func selectedToolPlan(projectDir, name string) toolBuildPlan {
 	if !ok || spec.ModulePath == "" {
 		return toolBuildPlan{mode: toolBuildIsolated, spec: spec}
 	}
-	cmd := exec.Command("go", "list", "-m", "-f", "{{.Path}}\t{{.Version}}\t{{.Main}}", spec.ModulePath)
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Path}}\t{{.Version}}\t{{.Main}}", spec.ModulePath) //nolint:gosec // spec comes from the fixed tool table.
 	cmd.Dir = projectDir
 	out, err := cmd.Output()
 	if err != nil {
@@ -347,7 +347,7 @@ func ensureTool(projectDir, toolsPath, toolName string, force, verbose bool) err
 	plan := selectedToolPlan(projectDir, toolName)
 	var cmd *exec.Cmd
 	if plan.mode == toolBuildVersioned {
-		cmd = exec.Command("go", "install", spec.ImportPath+"@"+plan.version)
+		cmd = exec.Command("go", "install", spec.ImportPath+"@"+plan.version) //nolint:gosec // spec and version come from the fixed tool plan.
 		cmd.Dir = projectDir
 		cmd.Env = append(os.Environ(), "GOBIN="+filepath.Join(toolsPath, "bin"))
 	} else {

--- a/cmd/aptre/cmd-generate_test.go
+++ b/cmd/aptre/cmd-generate_test.go
@@ -509,7 +509,7 @@ message Dependency { string value = 1; }
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(wktDir, "timestamp.proto"), wkt, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(wktDir, "timestamp.proto"), wkt, 0o644); err != nil { //nolint:gosec // wktDir is inside t.TempDir.
 		t.Fatal(err)
 	}
 	goMod := []byte("module github.com/example/project\n\ngo 1.25.0\n")
@@ -549,7 +549,7 @@ message Dependency { string value = 1; }
 			t.Fatalf("%s rewrote WKT import", rel)
 		}
 	}
-	cmd := exec.Command("uv", "run", "--directory", filepath.Join(rootDir, "tests", "python"), "python", "-c", "import sys; sys.path.insert(0, sys.argv[1]); import app.app_pb2", projectDir)
+	cmd := exec.Command("uv", "run", "--directory", filepath.Join(rootDir, "tests", "python"), "python", "-c", "import sys; sys.path.insert(0, sys.argv[1]); import app.app_pb2", projectDir) //nolint:gosec // arguments are fixed or test-owned paths.
 	cmd.Env = append(os.Environ(), "UV_PROJECT_ENVIRONMENT="+filepath.Join(t.TempDir(), ".venv"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("generated Python import: %v\\n%s", err, out)

--- a/protogen/cache.go
+++ b/protogen/cache.go
@@ -91,11 +91,11 @@ func (c *Cache) SetToolVersions(versions string) {
 	c.ToolVersions = versions
 }
 
-// NeedsRegeneration checks if a proto file needs regeneration.
+// NeedsRegeneration checks if a cached package needs regeneration.
 // Returns true if:
-// - The file is not in the cache
-// - The file content hash has changed
-// - The protoc flags have changed
+// - The package is not in the cache
+// - The proto file list or content hash has changed
+// - The protoc flags or selected tool versions have changed
 // - Force is true
 func (c *Cache) NeedsRegeneration(packageKey string, protoFiles []string, projectDir string, flagsHash string, toolVersions string, force bool) (bool, error) {
 	if force {

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1096,6 +1096,7 @@ github.com/sigstore/timestamp-authority/v2 v2.1.2/go.mod h1:o6rAVZceFyejClIj/uSt
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.5-0.20260508084601-d4a50659cfd6 h1:D6qewLO/pJ+JvUwuri1dmCbc32d/eO+xyqg+p3N+9kA=
 github.com/sirupsen/logrus v1.9.5-0.20260508084601-d4a50659cfd6/go.mod h1:FXZFonkDAnFozmO+5hGAFvB0Yg9/j2SIhA/QuIkP180=
+github.com/sirupsen/logrus v1.9.5-0.20260629095817-a23d315dfebb h1:+C8W2sTMIRbihe5hQH6JuT2mi3m/QgdGf0YdFyx2azA=
 github.com/sirupsen/logrus v1.9.5-0.20260629095817-a23d315dfebb/go.mod h1:FXZFonkDAnFozmO+5hGAFvB0Yg9/j2SIhA/QuIkP180=
 github.com/sivchari/containedctx v1.0.3 h1:x+etemjbsh2fB5ewm5FeLNi5bUjK0V8n0RB+Wwfd0XE=
 github.com/sivchari/containedctx v1.0.3/go.mod h1:c1RDvCbnJLtH4lLcYD/GqwiBSSf4F5Qk0xld2rBqzJ4=


### PR DESCRIPTION
The Common test job now reaches Python import validation and the complete Go lint pass. The tools module lacks the checksum for its selected logrus version, so lint cannot load before analysis. The current gosec release also flags two fixed tool commands and two test-owned paths as tainted.

Record the selected logrus checksum. Mark the fixed tool table and temporary test paths at their command and write sites so gosec can distinguish them from untrusted input.

Update the cache comment to include tool-version invalidation and package-level cache admission. The complete Go linter, generated Python import test, and protogen suite now pass.