### PR TITLE
fix(aptre): remove custom golangci-lint stamp on tool invalidation

### DIFF
--- a/cmd/aptre/cmd-deps.go
+++ b/cmd/aptre/cmd-deps.go
@@ -258,9 +258,22 @@ func reconcileToolsStamp(stampPath, identity string, extract func() error, inval
 	return true, nil
 }
 
+func customGolangCIStampPath(toolsPath string) string {
+	return filepath.Join(toolsPath, "bin", ".golangci-lint-custom-stamp")
+}
+
 func invalidateToolBinaries(toolsPath string) error {
+	paths := make([]string, 0, len(defaultTools)+1)
 	for _, spec := range defaultTools {
-		if err := os.Remove(filepath.Join(toolsPath, "bin", spec.Name)); err != nil && !os.IsNotExist(err) {
+		paths = append(paths, filepath.Join(toolsPath, "bin", spec.Name))
+	}
+	// The custom golangci-lint build replaces bin/golangci-lint and records its
+	// version and config in this stamp. Removing the binary while keeping the
+	// stamp makes the next ensureTool rebuild the stock binary, which cannot
+	// resolve the configured plugin linters.
+	paths = append(paths, customGolangCIStampPath(toolsPath))
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}
@@ -425,7 +438,7 @@ func maybeBuildCustomGolangCILint(projectDir, toolsPath string, verbose bool) er
 		return fmt.Errorf("missing version in %s", customConfPath)
 	}
 	baseLintPath := filepath.Join(toolsPath, "bin", "golangci-lint")
-	customStampPath := filepath.Join(toolsPath, "bin", ".golangci-lint-custom-stamp")
+	customStampPath := customGolangCIStampPath(toolsPath)
 	customStamp := strings.Join([]string{version, customConfPath}, "\n")
 	if stampDat, err := os.ReadFile(customStampPath); err == nil && string(stampDat) == customStamp {
 		return nil

--- a/cmd/aptre/cmd-deps_test.go
+++ b/cmd/aptre/cmd-deps_test.go
@@ -114,6 +114,32 @@ func TestReconcileToolsStampFailedExtractionDoesNotAdvance(t *testing.T) {
 	}
 }
 
+func TestInvalidateToolBinariesRemovesCustomGolangCIStamp(t *testing.T) {
+	d := t.TempDir()
+	bin := filepath.Join(d, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, spec := range defaultTools {
+		if err := os.WriteFile(filepath.Join(bin, spec.Name), []byte("old"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A custom golangci-lint build replaced the stock binary and wrote its
+	// stamp; invalidation must drop the stamp with the binary so the next
+	// ensureTool run rebuilds the custom build instead of the stock one.
+	stamp := filepath.Join(bin, ".golangci-lint-custom-stamp")
+	if err := os.WriteFile(stamp, []byte("v1\n/conf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := invalidateToolBinaries(d); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stamp); !os.IsNotExist(err) {
+		t.Fatalf("custom stamp retained: %v", err)
+	}
+}
+
 func TestInvalidateToolBinariesPreservesUnrelatedFiles(t *testing.T) {
 	d := t.TempDir()
 	bin := filepath.Join(d, "bin")


### PR DESCRIPTION
Tool invalidation deleted bin/golangci-lint but kept the custom-build stamp beside it. The next ensureTool run rebuilt the stock binary, and maybeBuildCustomGolangCILint saw a matching stamp and skipped the custom plugin build. Every later golangci-lint invocation then failed to resolve the configured plugin linters until .tools/bin was removed by hand.

This names the stamp path once and removes it together with the tool binaries during invalidation, so a rebuilt binary either matches the stamp or gets a fresh custom build.

TestInvalidateToolBinariesRemovesCustomGolangCIStamp fails against the old invalidation and passes with this change.